### PR TITLE
Fix extraEnvVars usage

### DIFF
--- a/charts/directus/Chart.yaml
+++ b/charts/directus/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.09
+version: 0.9.10
 
 # This is the version number of the application being deployed. They should reflect the version
 # the application is using.

--- a/charts/directus/templates/deployment.yaml
+++ b/charts/directus/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
           {{- if .Values.extraEnvVars }}
           envFrom:
           - configMapRef:
-            name: {{ include "directus.fullname" . }}-extra-environment-variables
+              name: {{ include "directus.fullname" . }}-extra-environment-variables
           {{- end }}
           volumeMounts:
             - name: uploads
@@ -186,7 +186,7 @@ spec:
           {{- if .Values.extraEnvVars }}
           envFrom:
           - configMapRef:
-            name: {{ include "directus.fullname" . }}-extra-environment-variables
+              name: {{ include "directus.fullname" . }}-extra-environment-variables
           {{- end }}
           volumeMounts:
             - mountPath: /startup-snapshot
@@ -291,7 +291,7 @@ spec:
           {{- if .Values.extraEnvVars }}
           envFrom:
           - configMapRef:
-            name: {{ include "directus.fullname" . }}-extra-environment-variables
+              name: {{ include "directus.fullname" . }}-extra-environment-variables
           {{- end }}
           volumeMounts:
 {{- if .Values.snapshot }}

--- a/charts/directus/templates/extra-envs.yaml
+++ b/charts/directus/templates/extra-envs.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "directus.labels" . | nindent 4 }}
 data:
 {{- range .Values.extraEnvVars }}
-  {{ .name }}: {{ .value }}
+  {{ .name }}: {{ .value | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR fix the generated manifest when using `extraEnvVars` values.
It add a missing indentation and ensure env var values are quoted, so YAML boolean value won't cause issues.